### PR TITLE
Fix git description

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-version = $(shell git describe --always --dirty)
+version = $(shell git describe --always --tags --dirty)
 
 build : constitution.pdf bylaws.pdf
 


### PR DESCRIPTION
The names for released governing docs are determined by a `git describe` command, with the idea being that tagged versions will get `-vX.Y.Z` appended to their filenames to distinguish them from other released versions.
The earlier command gave a correct name when tested earlier but created files like `constitution-9f19e3a.pdf` when we deployed. Adding the `--tag` command uses non-annotated tags as
well (like ones created through GitHub's web interface), and _should_ fix the issue.

You can try it yourself on a Linux machine by running `make build-tagged` and checking the filenames (you'll need [a recent version of pandoc](https://github.com/jgm/pandoc/releases/latest)).