### PR TITLE
BA-1819-002: Updating virtual funds

### DIFF
--- a/bylaws.md
+++ b/bylaws.md
@@ -692,13 +692,9 @@ funds:
 5. the SAC Budget, which is managed and allocated by the Student Activities
    Committee,
 6. the CCO Budget, which is managed and allocated by the Committee for Clubs and
-   Organizations,
+   Organizations, and
 7. the SERV Budget, which is managed and allocated by the Committee for
-   Supporting, Encouraging, and Recognizing Volunteerism,
-8. the Sports Fund, which is managed and allocated by the College’s Office
-   of Student Affairs and Resources, and
-9. the Recreational Health Organization Fund, which is managed and allocated by
-   the College’s Office of Student Affairs and Resources.
+   Supporting, Encouraging, and Recognizing Volunteerism.
 
 Some money from the Student Activities Fund may remain unallocated for later
 allocation as necessary.


### PR DESCRIPTION
Removing the Sports Fund and the Recreational Health Organization Fund from the list of virtual funds established by Allocation Order 0. The funds were merged into the Recreational Health Organizational Fund in the 2015-2016 school year. In the 2017-2018 year, Student Government voted to remove both of these funds from the budget and instead allocate for Sports and Recreational Health on a case-by-case basis. 