### PR TITLE
BA-1920-004 Increased scope of SG members who Student Body can propose by-law amendments to. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Originally passed at a meeting of the Student Government on May 1st, 2015.
 
 ### Passed Amendments
 
+- 2019-11-07 BA-1920-004: Increased scope of SG members who Student Body can
+  propose by-law amendments to.
 - 2019-11-07 BA-1920-003: Generalized wording on the forms transparency
   documents can take.
 - 2019-11-07 BA-1920-002: Added committee appointment process to CORe bylaws.

--- a/bylaws.md
+++ b/bylaws.md
@@ -1040,10 +1040,10 @@ Student Body within 24 hours of the close of the meeting.
 
 #### Section 2. Amending the By-Laws.
 
-Any member of the Student Body may propose an amendment to the By-Laws by
-presenting the amendment in written form to the President of the Student
-Government at least one week in advance of the meeting of the Student
-Government at which the author would like the amendment to be addressed.
+Any member of the Student Body may propose an amendment to the By-Laws by 
+presenting the amendment in written form to any voting member of the Student 
+Government at least one week in advance of the meeting of the Student 
+Government at which the author would like the amendment to be addressed. 
 
 The Vice President for Communications sends an announcement to the Student
 Body about the amendment at least three days in advance of the next Student

--- a/bylaws.md
+++ b/bylaws.md
@@ -1040,10 +1040,10 @@ Student Body within 24 hours of the close of the meeting.
 
 #### Section 2. Amending the By-Laws.
 
-Any member of the Student Body may propose an amendment to the By-Laws by 
-presenting the amendment in written form to any voting member of the Student 
-Government at least one week in advance of the meeting of the Student 
-Government at which the author would like the amendment to be addressed. 
+Any member of the Student Body may propose an amendment to the By-Laws by
+presenting the amendment in written form to any voting member of the Student
+Government at least one week in advance of the meeting of the Student
+Government at which the author would like the amendment to be addressed.
 
 The Vice President for Communications sends an announcement to the Student
 Body about the amendment at least three days in advance of the next Student


### PR DESCRIPTION
The bylaws are supposed to be flexible, and increasing the number of people who a member of the Student Body can present an amendment to makes sense. Keeping it to voting members so that we can make sure that things get addressed without huge overhead/confusion.