### PR TITLE
BA-1920-006: Change List of Student Groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Originally passed at a meeting of the Student Government on May 1st, 2015.
 
 ### Passed Amendments
 
+- 2019-12-05 BA-1920-006: Change list of student groups.
 - 2019-12-05 BA-1920-005: Add winter elections.
 - 2019-11-07 BA-1920-004: Increased scope of SG members who Student Body can
   propose by-law amendments to.

--- a/bylaws.md
+++ b/bylaws.md
@@ -1156,11 +1156,9 @@ is in reverse-chronological order (with the most recent Official Action at the
 top), and contains the full text of every Official Action, as well as a brief
 summary of the action if necessary.
 
-**The List of Student Groups and Administration Committees.** This document
-contains the names, descriptions, and officers or appointees of all recognized
-and unrecognized student clubs and organizations, branches of the student
-government, Council Projects, project teams, and Faculty and Operational
-Committees established by the Administration of the College.
+**The List of Student Groups.** This document contains the names, descriptions,
+and officers or appointees of all student clubs and organizations, branches
+of the student government, administrative committees, and project teams.
 
 **The Report on the Student Activities Fund.** As described in [Article 2, Section 2](#section-2-executives),
 The Vice President for Finance creates a State of the Student Activities Fund


### PR DESCRIPTION
Changed wording for list of student groups to more accurately reflect current state of what Olin students are involved in.

Changed the name to just "List of Student Groups"  - we serve on very few Administrative Committees these days, and it seems fair to state that the student(s) appointed to an administrative committee are among the student groups. It also ensures that folks don't think that only the Administrative Committees listed are the ones that exist at Olin, because there are plenty there are no students on. 

Considering the sheer breadth of different on-campus committees and groups, it seems important to maintain the scope to something that we can actually comprehensively track (and of course allow for more). For that reason, changing the "recognized and unrecognized student clubs and organizations, branches of the student government, Council Projects, project teams, and Faculty and Operational
Committees established by the Administration of the College." to "student clubs and organizations, branches of the student government, administrative committees, and project teams" provides a set of groups to keep track of that hopefully reflects what is set-in-stone enough to openly document.
