### PR TITLE
BA-1920-008: Assigned club fair and transparency document responsibilities to CCO 

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Originally passed at a meeting of the Student Government on May 1st, 2015.
 
 ### Passed Amendments
 
+- 2020-02-05 BA-1920-008: Assigned club fair and transparency document
+  responsibilities to CCO
 - 2019-12-05 BA-1920-007: Create more clearly outlined audit process.
 - 2019-12-05 BA-1920-006: Change list of student groups.
 - 2019-12-05 BA-1920-005: Add winter elections.

--- a/bylaws.md
+++ b/bylaws.md
@@ -495,8 +495,8 @@ activities. The Director approves the creation of Student Groups, classifies
 them as Clubs or Organizations, and generally helps them meet their goals. The
 Director will ensure that the Vice President for Finance has access to
 up-to-date Student Group spendings at all times. The Director populates and
-maintains the List of Student Groups and Administration Committees as described
-in [Article 13](#article-13-transparency). The Director attends meetings of the
+maintains the List of Student Groups as described in
+[Article 13](#article-13-transparency). The Director attends meetings of the
 Student Government prepared to report the activities and spending of the
 Committee. With the agreement of the Assistant Director, the Director may
 appropriate money from the CCO Budget.
@@ -621,6 +621,12 @@ A club or organization may organize the event with another Student Government
 Committee and receive funding from beyond the limits of Committee for Clubs and
 Organizations funding. This spending must be approved by the Officers of both
 Committees.
+
+### Section 10. Student Involvement Fair.
+
+The Committee hosts an annual student involvement fair at the beginning of each
+academic year so that student groups can advertise their presence and recruit
+new members. They also organize additional club fairs as needed.
 
 ### Article 6. The Committee for Supporting, Encouraging, and Recognizing Volunteerism.
 
@@ -1181,7 +1187,8 @@ summary of the action if necessary.
 
 **The List of Student Groups.** This document contains the names, descriptions,
 and officers or appointees of all student clubs and organizations, branches
-of the student government, administrative committees, and project teams.
+of the student government, administrative committees, and project teams. The
+Director of the Committee for Clubs and Organizations maintains this document.
 
 **The Report on the Student Activities Fund.** As described in [Article 2, Section 2](#section-2-executives),
 The Vice President for Finance creates a State of the Student Activities Fund

--- a/bylaws.md
+++ b/bylaws.md
@@ -1187,8 +1187,7 @@ summary of the action if necessary.
 
 **The List of Student Groups.** This document contains the names, descriptions,
 and officers or appointees of all student clubs and organizations, branches
-of the student government, administrative committees, and project teams. The
-Director of the Committee for Clubs and Organizations maintains this document.
+of the student government, administrative committees, and project teams.
 
 **The Report on the Student Activities Fund.** As described in [Article 2, Section 2](#section-2-executives),
 The Vice President for Finance creates a State of the Student Activities Fund


### PR DESCRIPTION
Created additional changes to CCO section of by-laws based on [Issue 20](https://github.com/olin/studentgovernment/issues/20). There are two main changes covered by this PR. 

1.) Add an additional section in the CCO section making them responsible for organizing the club fair at the beginning of the year. I also added a sentence regarding other club fairs (such as at Candidates' Weekend and open houses) but did not place hard-and-fast requirements on their sole responsibility for organizing it as those are often a joint effort with admissions and/or DFAR/

2.) Update the name of the List of Student Groups in the CCO documentation. This name was updated earlier this year as part of  BA-1920-006, but we did not update this section. 