### PR TITLE
BA-1920-009: Changed default election monitor in the case of no candidates.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Originally passed at a meeting of the Student Government on May 1st, 2015.
 
 ### Passed Amendments
 
+- 2020-02-05 BA-1920-009: Changed default election monitor in the case of no
+  candidates
 - 2020-02-05 BA-1920-008: Assigned club fair and transparency document
   responsibilities to CCO
 - 2019-12-05 BA-1920-007: Create more clearly outlined audit process.

--- a/bylaws.md
+++ b/bylaws.md
@@ -834,7 +834,8 @@ candidate with the most votes becomes Election Monitor. In the case of no
 candidates, the Senior Class representative performs the duties of the Election
 Monitor. If the Senior Class representative is not eligible to perform the
 duties of the Election Monitor, the presiding officer of the Council appoints
-an Election Monitor.
+an Election Monitor. The Student Government must approve this appointment
+through an internal election.
 
 In the case of a Special Election, where calling a meeting of the Student
 Government only to elect an Election Monitor would be inexpedient, the

--- a/bylaws.md
+++ b/bylaws.md
@@ -831,8 +831,10 @@ In the case of multiple candidates, each candidate gives a brief statement
 and is asked by the President to leave the room. The remaining members of
 the Student Government may deliberate and vote by excellence voting. The
 candidate with the most votes becomes Election Monitor. In the case of no
-candidates, the Dean of Student Life performs the duties of the Election
-Monitor.
+candidates, the Senior Class representative performs the duties of the Election
+Monitor. If the Senior Class representative is not eligible to perform the
+duties of the Election Monitor, the presiding officer of the Council appoints
+an Election Monitor.
 
 In the case of a Special Election, where calling a meeting of the Student
 Government only to elect an Election Monitor would be inexpedient, the

--- a/bylaws.md
+++ b/bylaws.md
@@ -839,8 +839,8 @@ the Student Government may deliberate and vote by excellence voting. The
 candidate with the most votes becomes Election Monitor. In the case of no
 candidates, the Senior Class representative performs the duties of the Election
 Monitor. If the Senior Class representative is not eligible to perform the
-duties of the Election Monitor, the presiding officer of the Council appoints
-an Election Monitor. The Student Government must approve this appointment
+duties of the Election Monitor, the presiding officer of the Council nominates
+an Election Monitor. The Student Government must approve this nomination
 through an internal election.
 
 In the case of a Special Election, where calling a meeting of the Student


### PR DESCRIPTION
The current iteration of the by-laws appoints the Dean of Student Life to act as the election monitor in the case of no candidates. While it is kind of the Dean to act in this role, this decision does not align with the student-centered purpose and sense of personal responsibility inherent to Student Government. For that reason, I am proposing we instead ask the Senior Class representative to act as the election monitor if there are no candidates. In the case where they are not eligible to act in this role, then, following the procedure used for special elections, the presiding officer can determine who the election monitor ought to be (and then could designate the Dean of Student Life). To ensure that the presiding officer does not misuse this power, the Government must approve this choice through an internal election. 