### PR TITLE
CA-1920-007: Acknowledge that student activities fee billing is done each semester, not each year. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Re-ratified at a Town Meeting on April 13th, 2018.
 
 ### Passed Amendments
 
+- [2020-02-12 CA-1920-007: Acknowledge that student activities fee is done every semester, not every year.](https://github.com/olin/studentgovernment/pull/72)
 - [2020-02-12 CA-1920-006: Generalize definition of bylaws.](https://github.com/olin/studentgovernment/pull/76)
 - [2020-02-12 CA-1920-005: Automatically defer power to assistant director when Committee Director is not present.](https://github.com/olin/studentgovernment/pull/75)
 - [2020-02-12 CA-1920-004: Clarified role of CORe in opening section.](https://github.com/olin/studentgovernment/pull/74)

--- a/constitution.md
+++ b/constitution.md
@@ -66,8 +66,8 @@ the trust of the Administration and Board of Trustees of the College.
 #### Section 5. Student Activities Fee.
 
 The Board of Trustees of the College has ultimate authority over the Student
-Activities Fee, which each student pays annually. The Student Government may
-recommend changes to the Student Activities Fee to the Board of Trustees.
+Activities Fee, which each student pays each semester. The Student Government
+may recommend changes to the Student Activities Fee to the Board of Trustees.
 
 #### Section 6. Student Activities Fund.
 


### PR DESCRIPTION
Updated Article 3 Section 5 to acknowledge that SAF income is from two semesters of billing of each student, not a single annual charge. Based on issue [67](https://github.com/olin/studentgovernment/issues/67)