### PR TITLE
CA-1920-003 : Refer to the by-laws for the committee appointment process.

### DIFF
--- a/constitution.md
+++ b/constitution.md
@@ -135,7 +135,7 @@ If a committee or working group of faculty and/or staff requests student
 representative(s), the Council may solicit volunteers from the Student Body to
 fill the representative positions on that committee. If there are more
 volunteers than available positions, the Council will appoint students by
-a procedure codified in the Student Government By-Laws.
+a procedure codified in the Student Government Bylaws.
 
 #### Section 8. Appellate Authority.
 

--- a/constitution.md
+++ b/constitution.md
@@ -135,7 +135,7 @@ If a committee or working group of faculty and/or staff requests student
 representative(s), the Council may solicit volunteers from the Student Body to
 fill the representative positions on that committee. If there are more
 volunteers than available positions, the Council will appoint students by
-excellence voting.
+a procedure codified in the Student Government By-Laws.
 
 #### Section 8. Appellate Authority.
 


### PR DESCRIPTION
The reason to propose that this refer to the by-laws instead of making a vague blanket statement re: excellence voting is that the appointment process changes depending on the number of volunteers and the nature of the role. We rewrote some by-laws to try to make that more clear, but we still are iterating there and it also falls in too much detail to place in the Constitution. Keeping the Constitution as a pointer to the by-laws gives us the flexibility we need to make the right decision but still ensures we continue to follow a rigorous process. Refered to in issue [68](https://github.com/olin/studentgovernment/issues/68)