### PR TITLE
CA-1920-003 : Refer to the by-laws for the committee appointment process

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Re-ratified at a Town Meeting on April 13th, 2018.
 
 ### Passed Amendments
 
+- [2020-02-12 CA-1920-003: Refer to the bylaws for committee appointment process](https://github.com/olin/studentgovernment/pull/83)
 - [2020-02-12 CA-1920-002: Change spelling of by-laws to bylaws](https://github.com/olin/studentgovernment/pull/78)
 - [2020-02-12 CA-1920-001: Update constitution sunset to 2022](https://github.com/olin/studentgovernment/pull/64)
 - [2018-04-13 CA-1718-001: Resurrect the constitution](https://github.com/olin/studentgovernment/pull/37)

--- a/constitution.md
+++ b/constitution.md
@@ -135,7 +135,7 @@ If a committee or working group of faculty and/or staff requests student
 representative(s), the Council may solicit volunteers from the Student Body to
 fill the representative positions on that committee. If there are more
 volunteers than available positions, the Council will appoint students by
-excellence voting.
+a procedure codified in the Student Government Bylaws.
 
 #### Section 8. Appellate Authority.
 


### PR DESCRIPTION
The reason to propose that this refer to the by-laws instead of making a vague blanket statement re: excellence voting is that the appointment process changes depending on the number of volunteers and the nature of the role. We rewrote some by-laws to try to make that more clear, but we still are iterating there and it also falls in too much detail to place in the Constitution. Keeping the Constitution as a pointer to the by-laws gives us the flexibility we need to make the right decision but still ensures we continue to follow a rigorous process. Refered to in issue 68

Changed spelling of by-law to bylaw to reflect PR CA-1920-003 with understanding that this could revert back.

